### PR TITLE
Updated triggers.py which returned error due to spelling mistake.

### DIFF
--- a/triggers.py
+++ b/triggers.py
@@ -29,7 +29,7 @@ class UseTrigger(Draggable):
         if not hasattr(self, 'player') or not self.player or self.disabled:
             return
 
-        self.dot.enabled = distance2d(self.world_position, self.player.world_position) < self.radius
+        self.dot.enabled = distance_2d(self.world_position, self.player.world_position) < self.radius
 
 
     def input(self, key):


### PR DESCRIPTION
**When running the ```main.py```, the  line 32 of ```triggers.py``` returned error due to spelling mistake.**

> NameError: name 'distance2d' is not defined.

I've fixed that issue in this pull request.