### PR TITLE
Updated triggers.py, which returned error due to spelling mistake.

### DIFF
--- a/triggers.py
+++ b/triggers.py
@@ -29,7 +29,7 @@ class UseTrigger(Draggable):
         if not hasattr(self, 'player') or not self.player or self.disabled:
             return
 
-        self.dot.enabled = distance2d(self.world_position, self.player.world_position) < self.radius
+        self.dot.enabled = distance_2d(self.world_position, self.player.world_position) < self.radius
 
 
     def input(self, key):


### PR DESCRIPTION
**While running ```main.py```, the error raises in 32nd line of ```triggers.py``` due to a spelling mistake.**

> NameError: name 'distance2d' is not defined.

The problem is fixed in this pull request.